### PR TITLE
Remove hard-coded base host_parts.length of 2 and add support for site subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Divergence::Application.configure do |config|
   config.app_path = "/path/to/app_root"
   config.cache_path = "/path/to/cache_root"
 
+  config.incoming_base_uri = 'example.com'
+
   config.forward_host = 'localhost'
   config.forward_port = 80
 

--- a/generators/files/config.rb
+++ b/generators/files/config.rb
@@ -22,4 +22,13 @@ Divergence::Application.configure do |config|
   # so update your web application to run on a different port.
   config.forward_host = 'localhost'
   config.forward_port = 80
+
+  # If your site code is used for more than one virtual host, with
+  # one being a subdomain of the other (e.g. example.com and
+  # api.example.com) and both under the same git repository, you can supply
+  # the additional domains in the config.site_subdomains array.
+  # Note: if you use a config.forward_host value of 'localhost', then
+  # Divergence will make the request to api.localhost, so you probably
+  # want to use a different forward_host.
+  # config.site_subdomains = ['api']
 end

--- a/generators/files/config.rb
+++ b/generators/files/config.rb
@@ -11,6 +11,10 @@ Divergence::Application.configure do |config|
   # have it's own Passenger instance, so don't get too carried away.
   # config.cache_num = 5
 
+  # Incoming base domain for requests, which will have a
+  # branch name prepended to it
+  config.incoming_base_uri = 'example.com'
+
   # Where should we proxy this request to? Normally you can leave
   # the host as 'localhost', but if you are using virtual hosts in
   # your web server setup, you may need to be more specific. You

--- a/lib/divergence/config.rb
+++ b/lib/divergence/config.rb
@@ -5,6 +5,7 @@ module Divergence
     attr_accessor :app_path, :git_path, :cache_path
     attr_accessor :cache_num
     attr_accessor :forward_host, :forward_port
+    attr_accessor :site_subdomains
     attr_reader :incoming_base_uri_length
 
     def initialize
@@ -17,14 +18,15 @@ module Divergence
       @incoming_base_uri_length = 2
       @forward_host = 'localhost'
       @forward_port = 80
+      @site_subdomains = []
 
       @callback_store = {}
       @helpers = Divergence::Helpers.new(self)
     end
 
-    def incoming_base_uri=(base_uri)
-      @incoming_base_uri = base_uri
-      @incoming_base_uri_length = @base_uri.split(".").length
+    def incoming_base_uri=(incoming_base_uri)
+      @incoming_base_uri = incoming_base_uri
+      @incoming_base_uri_length = @incoming_base_uri.split(".").length
     end
 
     def ok?

--- a/lib/divergence/config.rb
+++ b/lib/divergence/config.rb
@@ -5,6 +5,7 @@ module Divergence
     attr_accessor :app_path, :git_path, :cache_path
     attr_accessor :cache_num
     attr_accessor :forward_host, :forward_port
+    attr_reader :incoming_base_uri_length
 
     def initialize
       @git_path = nil
@@ -13,11 +14,17 @@ module Divergence
 
       @cache_num = 5
 
+      @incoming_base_uri_length = 2
       @forward_host = 'localhost'
       @forward_port = 80
 
       @callback_store = {}
       @helpers = Divergence::Helpers.new(self)
+    end
+
+    def incoming_base_uri=(base_uri)
+      @incoming_base_uri = base_uri
+      @incoming_base_uri_length = @base_uri.split(".").length
     end
 
     def ok?

--- a/lib/divergence/request_parser.rb
+++ b/lib/divergence/request_parser.rb
@@ -19,7 +19,7 @@ module Divergence
     end
 
     def has_subdomain?
-      host_parts.length > 2
+      host_parts.length > @config.incoming_base_uri_length
     end
 
     def subdomain


### PR DESCRIPTION
I removed the hard-coded value of host_parts.length > 2 for has_subdomain?(), and I added support for git repos whose code is used for additional subdomains, e.g. example.com and api.example.com. I was also having problems getting Divergence to work behind a proxy (which is handling SSL), so now Rack::Proxy support a backend_uri option (https://github.com/ncr/rack-proxy/pull/15), which I added to Divergence in fix_environment!().
